### PR TITLE
Deal with rustup being preinstalled

### DIFF
--- a/az-pipeline/unstable/rustup.yml
+++ b/az-pipeline/unstable/rustup.yml
@@ -6,15 +6,18 @@ parameters:
 steps:
 # Linux and macOS.
 - script: |
-    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${{ parameters.rustup_toolchain }}
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
+    export PATH=$PATH:$HOME/.cargo/bin
+    rustup default ${{ parameters.rustup_toolchain }}
     echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
   condition: ne( variables['Agent.OS'], 'Windows_NT' )
   displayName: Install rust
 # Windows.
 - script: |
     curl -sSf -o rustup-init.exe https://win.rustup.rs
-    rustup-init.exe -y --default-toolchain ${{ parameters.rustup_toolchain }}
+    rustup-init.exe -y --default-toolchain none
     set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+    rustup default ${{ parameters.rustup_toolchain }}
     echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
   condition: eq( variables['Agent.OS'], 'Windows_NT' )
   displayName: Install rust (windows)


### PR DESCRIPTION
As of this commit: https://github.com/microsoft/azure-pipelines-image-generation/commit/f0f1dd4512a40f2a58549e809f1db9fc734ebfd0#diff-f87405c9dd43f633a04dd078666d61af

Some (but not all) azure images have rustup/cargo/rustc preinstalled. This actually makes the rustup.yml here go wrong.

That's because sh.rustup.rs ignores the `--default-toolchain` option totally when it detects a preexisting rustup installed:

```
root@a360a00dd908:/# curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
info: downloading installer
(...)
  nightly installed - rustc 1.37.0-nightly (4edff843d 2019-06-16)
(...)

root@a360a00dd908:/# curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
info: downloading installer
info: updating existing rustup installation


Rust is installed now. Great!

To get started you need Cargo's bin directory ($HOME/.cargo/bin) in your PATH 
environment variable. Next time you log in this will be done automatically.

To configure your current shell run source $HOME/.cargo/env
root@a360a00dd908:/# export PATH=$PATH:$HOME/.cargo/bin      
root@a360a00dd908:/# rustup default
nightly (default)
```

Observe that the second installation totally ignored the request for stable. That, IMO, is a bug.

This PR works around that by:

- trying to install via the old method, with no selected toolchain (this is needed for Windows and Mac)
- then running rustup to select the desired toolchain (which, on Linux, runs the preinstalled rustup)